### PR TITLE
Fix QIODevice Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ autom4te.cache/
 qzdl
 qzdl.pro.user
 zdl
+.qmake.stash

--- a/src/qzdl.cpp
+++ b/src/qzdl.cpp
@@ -74,6 +74,7 @@ int main( int argc, char **argv ){
 	}
 	QStringList eatenArgs(args);
 	ZDLNullDevice nullDev;
+	nullDev.open(QIODevice::WriteOnly);
 #if defined(ZDL_BLACKBOX)
 	QFile *loggingFile = NULL;
 	zdlDebug = NULL;
@@ -305,6 +306,7 @@ int main( int argc, char **argv ){
 
 	tconf->writeINI(ZDLConfigurationManager::getConfigFileName());
 	LOGDATA() << "ZDL QUIT" << endl;
+	nullDev.close();
 	return ret;
 }
 


### PR DESCRIPTION
When I start your fork, I see an error message that isn't present in the Qt 4 version:

    QIODevice::write (QIODevice): device not open

This fixes it