### PR TITLE
Start DOOM process detached

### DIFF
--- a/src/ZDLMainWindow.cpp
+++ b/src/ZDLMainWindow.cpp
@@ -386,7 +386,7 @@ void ZDLMainWindow::launch(){
 	proc->setWorkingDirectory(workingDirectory);
 
 	proc->setProcessChannelMode(QProcess::ForwardedChannels);
-	proc->start(exec, args);
+	proc->startDetached(exec, args);
 	procerr = proc->error();
 #endif
 	int stat;


### PR DESCRIPTION
This allows ZDL to be closed while the DOOM process spawned from it is still running.

Without it, both ZDL and DOOM will simultaneously crash if you check "Close on launch", then click "Launch".